### PR TITLE
Add support for download translations by tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ build process from [PhraseApp API v2](http://docs.phraseapp.com/api/v2/).
         <configuration>
             <authToken>YOUR_AUTH_TOKEN(REQUIRED)</authToken>
             <projectId>YOUR_PROJECT_ID(REQUIRED)</projectId>
+            <tags>YOUR_TAGS_IN_THE_PROJECT(OPTIONAL)</tagName>
             
             <generatedResourcesFolderName>YOUR_GENERATED_RESOURCE_FOLDER(default:generated-resources/)</generatedResourcesFolderName>
             <messagesFolderName>YOUR_MESSAGES_FOLDERNAME(default:messages/)</messagesFolderName>

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
     <properties>
         <javaVersion>1.7</javaVersion>
         <mavenVersion>3.2.2</mavenVersion>
-        <phrase-java-client.version>1.0.6</phrase-java-client.version>
+        <phrase-java-client.version>1.0.7-SNAPSHOT</phrase-java-client.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <scm.connection>scm:git:git@github.com:mytaxi/phrase-maven-plugin.git</scm.connection>
         <scm.url>https://github.com/mytaxi/phrase-maven-plugin</scm.url>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.free-now.maven.plugins</groupId>
     <artifactId>phrase-plugin</artifactId>
-    <version>2.0.1-SNAPSHOT</version>
+    <version>2.1.0-SNAPSHOT</version>
 
     <packaging>maven-plugin</packaging>
     <name>phrase-plugin</name>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <properties>
         <javaVersion>1.8</javaVersion>
         <mavenVersion>3.2.2</mavenVersion>
-        <phrase-java-client.version>2.1.0</phrase-java-client.version>
+        <phrase-java-client.version>3.0.0</phrase-java-client.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <spring.version>3.2.15.RELEASE</spring.version>
     </properties>

--- a/src/main/java/com/mytaxi/plugins/PhraseAppMojo.java
+++ b/src/main/java/com/mytaxi/plugins/PhraseAppMojo.java
@@ -58,6 +58,12 @@ public class PhraseAppMojo extends AbstractMojo
     private String projectId;
 
     /**
+     * v2 Tags for the project you want to download the strings. *OPTIONAL
+     */
+    @Parameter(property = "tags")
+    private String tags;
+
+    /**
      * Location directory of the messages folder. Default: ${project.build.directory}/generated-resources/
      */
     @Parameter(property = "generatedResourcesFolderName")
@@ -101,12 +107,21 @@ public class PhraseAppMojo extends AbstractMojo
     {
         checkRequiredConfigurations();
 
-        getLog().info("Start downloading message resources ...");
+        final String message = tags == null
+                ? String.format("Start downloading message resources for project %s ...", projectId)
+                : String.format("Start downloading message resources for project %s and tag %s...", projectId, tags);
+        getLog().info(message);
 
         try
         {
             final URL parsedURL = new URL(url);
-            PhraseAppSyncTask phraseAppSyncTask = new PhraseAppSyncTask(authToken, projectId, parsedURL.getProtocol(), createHost(parsedURL));
+            PhraseAppSyncTask phraseAppSyncTask = new PhraseAppSyncTask(
+                    authToken,
+                    projectId,
+                    tags,
+                    parsedURL.getProtocol(),
+                    createHost(parsedURL)
+            );
             configure(phraseAppSyncTask);
             phraseAppSyncTask.run();
         }
@@ -118,8 +133,6 @@ public class PhraseAppMojo extends AbstractMojo
             }
 
             getLog().info("Error in getting PhraseApp strings due build process", e);
-
-
         }
 
         addingCompileSource();

--- a/src/main/java/com/mytaxi/plugins/PhraseAppMojo.java
+++ b/src/main/java/com/mytaxi/plugins/PhraseAppMojo.java
@@ -1,10 +1,9 @@
 package com.mytaxi.plugins;
 
+import com.freenow.apis.phrase.tasks.PhraseAppSyncTask;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
-import com.freenow.apis.phrase.tasks.PhraseAppSyncTask;
 import java.io.File;
-import java.net.URL;
 import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -109,20 +108,13 @@ public class PhraseAppMojo extends AbstractMojo
         checkRequiredConfigurations();
 
         final String message = tags == null
-                ? String.format("Start downloading message resources for project %s ...", projectId)
-                : String.format("Start downloading message resources for project %s and tag %s...", projectId, tags);
+            ? String.format("Start downloading message resources for project %s ...", projectId)
+            : String.format("Start downloading message resources for project %s and tags %s...", projectId, tags);
         getLog().info(message);
 
         try
         {
-            final URL parsedURL = new URL(url);
-            PhraseAppSyncTask phraseAppSyncTask = new PhraseAppSyncTask(
-                    authToken,
-                    projectId,
-                    tags,
-                    parsedURL.getProtocol(),
-                    createHost(parsedURL)
-            );
+            final PhraseAppSyncTask phraseAppSyncTask = new PhraseAppSyncTask(authToken, projectId, tags, url);
             configure(phraseAppSyncTask);
             phraseAppSyncTask.run();
         }
@@ -142,18 +134,6 @@ public class PhraseAppMojo extends AbstractMojo
     }
 
 
-    private String createHost(final URL parsedURL)
-    {
-        if (parsedURL.getPort() != -1)
-        {
-            return parsedURL.getHost() + parsedURL.getPath();
-        }
-        else
-        {
-            return String.format("%s:%d%s", parsedURL.getHost(), parsedURL.getPort(), parsedURL.getPath());
-        }
-    }
-
     private void addingCompileSource()
     {
         String generatedSourcePath = getGeneratedResourceFolder();
@@ -171,7 +151,8 @@ public class PhraseAppMojo extends AbstractMojo
     private void checkRequiredConfigurations()
     {
         getLog().info("Config: Check required configurations ...");
-        if (DEFAULT_PHRASE_HOST.equals(url)) {
+        if (DEFAULT_PHRASE_HOST.equals(url))
+        {
             Preconditions.checkNotNull(authToken, "AuthToken is not configured but is REQUIRED");
         }
         Preconditions.checkNotNull(projectId, "ProjectId is not configured but is REQUIRED", projectId);

--- a/src/test/java/com/mytaxi/plugins/IntegrationTest.java
+++ b/src/test/java/com/mytaxi/plugins/IntegrationTest.java
@@ -20,6 +20,7 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 @Ignore
@@ -30,6 +31,8 @@ public class IntegrationTest
     private final File mavenHome = new File(System.getenv("MVN_HOME"));
     private final File messageOutputDir = new File("target/test-classes/target/generated-resources/messages/");
     private static final String TESTING_KEY = "test-phrase-maven-plugin";
+    private static final String TESTING_TAG_KEY = "test-tag-phrase-maven-plugin";
+
 
     @Test
     public void testPom1() throws Exception
@@ -83,7 +86,26 @@ public class IntegrationTest
     }
 
 
+    @Test
+    public void shouldFetchTranslationsFilteredByTag() throws Exception
+    {
+        Properties properties = downloadTranslations(findTestPomFile("/test-pom5.xml"));
+        assertNotNull(properties.getProperty(TESTING_TAG_KEY));
+        assertNull(properties.getProperty(TESTING_KEY));
+    }
+
+
     private void testPom(File pomFile, String key, String expectedText) throws Exception
+    {
+        Properties properties = downloadTranslations(pomFile);
+
+        assertEquals(
+            expectedText,
+            properties.getProperty(key));
+    }
+
+
+    private Properties downloadTranslations(File pomFile) throws Exception
     {
         // invoke clean
         assertEquals(0, invokeMaven(pomFile, "clean"));
@@ -105,10 +127,7 @@ public class IntegrationTest
         {
             Properties properties = new Properties();
             properties.load(in);
-
-            assertEquals(
-                expectedText,
-                properties.getProperty(key));
+            return properties;
         }
     }
 

--- a/src/test/resources/test-pom1.xml
+++ b/src/test/resources/test-pom1.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>com.free-now.maven.plugins</groupId>
                 <artifactId>phrase-plugin</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
                 <configuration>
                     <authToken>${env.ENV_PHRASE_AUTHTOKEN}</authToken>
                     <projectId>${env.ENV_PHRASE_PROJECTID}</projectId>

--- a/src/test/resources/test-pom2.xml
+++ b/src/test/resources/test-pom2.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>com.free-now.maven.plugins</groupId>
                 <artifactId>phrase-plugin</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
                 <configuration>
                     <authToken>${env.ENV_PHRASE_AUTHTOKEN}</authToken>
                     <projectId>${env.ENV_PHRASE_PROJECTID}</projectId>

--- a/src/test/resources/test-pom3.xml
+++ b/src/test/resources/test-pom3.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>com.free-now.maven.plugins</groupId>
                 <artifactId>phrase-plugin</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
                 <configuration>
                     <url>${env.ENV_PHRASE_NOT_DEFAULT_HOST}</url>
                     <projectId>${env.ENV_PHRASE_PROJECTID}</projectId>

--- a/src/test/resources/test-pom4.xml
+++ b/src/test/resources/test-pom4.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>com.free-now.maven.plugins</groupId>
                 <artifactId>phrase-plugin</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
                 <configuration>
                     <projectId>${env.ENV_PHRASE_PROJECTID}</projectId>
                     <messageFilePrefix>test-messages_</messageFilePrefix>

--- a/src/test/resources/test-pom5.xml
+++ b/src/test/resources/test-pom5.xml
@@ -16,7 +16,7 @@
             <plugin>
                 <groupId>com.free-now.maven.plugins</groupId>
                 <artifactId>phrase-plugin</artifactId>
-                <version>2.0.1-SNAPSHOT</version>
+                <version>2.1.0-SNAPSHOT</version>
                 <configuration>
                     <authToken>${env.ENV_PHRASE_AUTHTOKEN}</authToken>
                     <projectId>${env.ENV_PHRASE_PROJECTID}</projectId>

--- a/src/test/resources/test-pom5.xml
+++ b/src/test/resources/test-pom5.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.mytaxi.maven.plugins.test</groupId>
+    <artifactId>test-phrase-plugin</artifactId>
+    <version>1.0.0-SNAPSHOT</version>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.free-now.maven.plugins</groupId>
+                <artifactId>phrase-plugin</artifactId>
+                <version>2.0.1-SNAPSHOT</version>
+                <configuration>
+                    <authToken>${env.ENV_PHRASE_AUTHTOKEN}</authToken>
+                    <projectId>${env.ENV_PHRASE_PROJECTID}</projectId>
+                    <tags>${env.ENV_PHRASE_TESTING_TAG}</tags>
+                    <messageFilePrefix>test-messages_</messageFilePrefix>
+                    <fileFormat>
+                        <name>properties</name>
+                        <options>
+                            <escape_single_quotes>false</escape_single_quotes>
+                        </options>
+                    </fileFormat>
+                </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>phrase</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>
+
+
+


### PR DESCRIPTION
Summary:
Download locales filtered by tags.

Implementation details:
- Bump version to 2.1.0
- Update `phrase-java-client` dependency to 3.0.0
- Support for Phrase tags in the plugin configuration